### PR TITLE
Support force option to Cha::API#room_messages

### DIFF
--- a/lib/cha/api.rb
+++ b/lib/cha/api.rb
@@ -134,9 +134,13 @@ module Cha
     # Get list of chat room messages
     #
     # @param room_id [Integer] ID of chat room
+    # @param params [Hash] Hash of optional parameter
+    # @option params [Boolean] :force (nil)
+    #   Whether to get the latest 100 Reviews regardless of the non-acquired
     # @return [Array<Hashie::Mash>]
-    def room_messages(room_id)
-      get("rooms/#{room_id}/messages")
+    def room_messages(room_id, params = {})
+      force = boolean_to_integer(params[:force])
+      get("rooms/#{room_id}/messages", force: force)
     end
 
     # Create new message of chat room

--- a/spec/cha/api_spec.rb
+++ b/spec/cha/api_spec.rb
@@ -94,9 +94,18 @@ describe Cha::API do
   end
 
   describe '#room_messages' do
-    it 'should request the correct resource' do
-      stub_get('rooms/1/messages')
-      client.room_messages(1)
+    context 'without force option' do
+      it 'should request the correct resource' do
+        stub_get('rooms/1/messages?force=0')
+        client.room_messages(1)
+      end
+    end
+
+    context 'with force option' do
+      it 'should request the correct resource' do
+        stub_get('rooms/1/messages?force=1')
+        client.room_messages(1, force: true)
+      end
     end
   end
 


### PR DESCRIPTION
Support new `force` option  of new API `GET /rooms/{room_id}/messages` 
# ref
- http://developer.chatwork.com/ja/changelogs.html 
- http://developer.chatwork.com/ja/endpoint_rooms.html#GET-rooms-room_id-messages
